### PR TITLE
Remove Cypress.moment from examples

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ jobs:
     - checkout
     # to avoid long "pulling image" progress on the first time we use
     # the Docker image, pull it first
-    - run: docker pull cypress/included:4.1.0
+    - run: docker pull cypress/included:6.3.0
     - run:
         command: docker-compose run e2e-electron
         no_output_timeout: 3m
@@ -20,7 +20,7 @@ jobs:
       docker_layer_caching: false
     steps:
     - checkout
-    - run: docker pull cypress/included:4.1.0
+    - run: docker pull cypress/included:6.3.0
     - run:
         command: docker-compose run e2e-chrome
         no_output_timeout: 3m

--- a/cypress/integration/examples/network_requests.spec.js
+++ b/cypress/integration/examples/network_requests.spec.js
@@ -2,7 +2,7 @@
 
 context('Network Requests', () => {
   beforeEach(() => {
-    cy.visit('http://localhost:8080/commands/network-requests')
+    cy.visit('https://example.cypress.io/commands/network-requests')
   })
 
   // Manage HTTP requests in your app

--- a/cypress/integration/examples/network_requests.spec.js
+++ b/cypress/integration/examples/network_requests.spec.js
@@ -2,69 +2,32 @@
 
 context('Network Requests', () => {
   beforeEach(() => {
-    cy.visit('https://example.cypress.io/commands/network-requests')
+    cy.visit('http://localhost:8080/commands/network-requests')
   })
 
-  // Manage AJAX / XHR requests in your app
-
-  it('cy.server() - control behavior of network requests and responses', () => {
-    // https://on.cypress.io/server
-
-    cy.server().should((server) => {
-      // the default options on server
-      // you can override any of these options
-      expect(server.delay).to.eq(0)
-      expect(server.method).to.eq('GET')
-      expect(server.status).to.eq(200)
-      expect(server.headers).to.be.null
-      expect(server.response).to.be.null
-      expect(server.onRequest).to.be.undefined
-      expect(server.onResponse).to.be.undefined
-      expect(server.onAbort).to.be.undefined
-
-      // These options control the server behavior
-      // affecting all requests
-
-      // pass false to disable existing route stubs
-      expect(server.enable).to.be.true
-      // forces requests that don't match your routes to 404
-      expect(server.force404).to.be.false
-      // whitelists requests from ever being logged or stubbed
-      expect(server.whitelist).to.be.a('function')
-    })
-
-    cy.server({
-      method: 'POST',
-      delay: 1000,
-      status: 422,
-      response: {},
-    })
-
-    // any route commands will now inherit the above options
-    // from the server. anything we pass specifically
-    // to route will override the defaults though.
-  })
+  // Manage HTTP requests in your app
 
   it('cy.request() - make an XHR request', () => {
     // https://on.cypress.io/request
     cy.request('https://jsonplaceholder.cypress.io/comments')
       .should((response) => {
         expect(response.status).to.eq(200)
-        expect(response.body).to.have.length(500)
+        // the server sometimes gets an extra comment posted from another machine
+        // which gets returned as 1 extra object
+        expect(response.body).to.have.property('length').and.be.oneOf([500, 501])
         expect(response).to.have.property('headers')
         expect(response).to.have.property('duration')
       })
   })
 
-
   it('cy.request() - verify response using BDD syntax', () => {
     cy.request('https://jsonplaceholder.cypress.io/comments')
-    .then((response) => {
-      // https://on.cypress.io/assertions
-      expect(response).property('status').to.equal(200)
-      expect(response).property('body').to.have.length(500)
-      expect(response).to.include.keys('headers', 'duration')
-    })
+      .then((response) => {
+        // https://on.cypress.io/assertions
+        expect(response).property('status').to.equal(200)
+        expect(response).property('body').to.have.property('length').and.be.oneOf([500, 501])
+        expect(response).to.include.keys('headers', 'duration')
+      })
   })
 
   it('cy.request() with query parameters', () => {
@@ -77,14 +40,14 @@ context('Network Requests', () => {
         id: 3,
       },
     })
-    .its('body')
-    .should('be.an', 'array')
-    .and('have.length', 1)
-    .its('0') // yields first element of the array
-    .should('contain', {
-      postId: 1,
-      id: 3,
-    })
+      .its('body')
+      .should('be.an', 'array')
+      .and('have.length', 1)
+      .its('0') // yields first element of the array
+      .should('contain', {
+        postId: 1,
+        id: 3,
+      })
   })
 
   it('cy.request() - pass result to the second request', () => {
@@ -109,9 +72,14 @@ context('Network Requests', () => {
       .then((response) => {
         expect(response).property('status').to.equal(201) // new entity created
         expect(response).property('body').to.contain({
-          id: 101, // there are already 100 posts, so new entity gets id 101
           title: 'Cypress Test Runner',
         })
+
+        // we don't know the exact post id - only that it will be > 100
+        // since JSONPlaceholder has built-in 100 posts
+        expect(response.body).property('id').to.be.a('number')
+          .and.to.be.gt(100)
+
         // we don't know the user id here - since it was in above closure
         // so in this test just confirm that the property is there
         expect(response.body).property('userId').to.be.a('number')
@@ -135,7 +103,7 @@ context('Network Requests', () => {
           title: 'Cypress Test Runner',
           body: 'Fast, easy and reliable testing for anything that runs in a browser.',
         })
-        .its('body').as('post') // save the new post from the response
+          .its('body').as('post') // save the new post from the response
       })
       .then(function () {
         // When this callback runs, both "cy.request" API commands have finished
@@ -145,42 +113,42 @@ context('Network Requests', () => {
       })
   })
 
-  it('cy.route() - route responses to matching requests', () => {
-    // https://on.cypress.io/route
+  it('cy.intercept() - route responses to matching requests', () => {
+    // https://on.cypress.io/intercept
 
     let message = 'whoa, this comment does not exist'
 
-    cy.server()
-
     // Listen to GET to comments/1
-    cy.route('GET', 'comments/*').as('getComment')
+    cy.intercept('GET', '**/comments/*').as('getComment')
 
     // we have code that gets a comment when
     // the button is clicked in scripts.js
     cy.get('.network-btn').click()
 
     // https://on.cypress.io/wait
-    cy.wait('@getComment').its('status').should('eq', 200)
+    cy.wait('@getComment').its('response.statusCode').should('be.oneOf', [200, 304])
 
     // Listen to POST to comments
-    cy.route('POST', '/comments').as('postComment')
+    cy.intercept('POST', '**/comments').as('postComment')
 
     // we have code that posts a comment when
     // the button is clicked in scripts.js
     cy.get('.network-post').click()
-    cy.wait('@postComment').should((xhr) => {
-      expect(xhr.requestBody).to.include('email')
-      expect(xhr.requestHeaders).to.have.property('Content-Type')
-      expect(xhr.responseBody).to.have.property('name', 'Using POST in cy.route()')
+    cy.wait('@postComment').should(({ request, response }) => {
+      expect(request.body).to.include('email')
+      expect(request.headers).to.have.property('content-type')
+      expect(response && response.body).to.have.property('name', 'Using POST in cy.intercept()')
     })
 
     // Stub a response to PUT comments/ ****
-    cy.route({
+    cy.intercept({
       method: 'PUT',
-      url: 'comments/*',
-      status: 404,
-      response: { error: message },
-      delay: 500,
+      url: '**/comments/*',
+    }, {
+      statusCode: 404,
+      body: { error: message },
+      headers: { 'access-control-allow-origin': '*' },
+      delayMs: 500,
     }).as('putComment')
 
     // we have code that puts a comment when

--- a/cypress/integration/examples/utilities.spec.js
+++ b/cypress/integration/examples/utilities.spec.js
@@ -72,34 +72,6 @@ context('Utilities', () => {
     expect(matching, 'comments').to.be.false
   })
 
-
-  it('Cypress.moment() - format or parse dates using a moment method', () => {
-    // https://on.cypress.io/moment
-    const time = Cypress.moment('2014-04-25T19:38:53.196Z').utc().format('h:mm A')
-
-    expect(time).to.be.a('string')
-
-    cy.get('.utility-moment').contains('3:38 PM')
-      .should('have.class', 'badge')
-
-    // the time in the element should be between 3pm and 5pm
-    const start = Cypress.moment('3:00 PM', 'LT')
-    const end = Cypress.moment('5:00 PM', 'LT')
-
-    cy.get('.utility-moment .badge')
-      .should(($el) => {
-        // parse American time like "3:38 PM"
-        const m = Cypress.moment($el.text().trim(), 'LT')
-
-        // display hours + minutes + AM|PM
-        const f = 'h:mm A'
-
-        expect(m.isBetween(start, end),
-          `${m.format(f)} should be between ${start.format(f)} and ${end.format(f)}`).to.be.true
-      })
-  })
-
-
   it('Cypress.Promise - instantiate a bluebird promise', () => {
     // https://on.cypress.io/promise
     let waited = false


### PR DESCRIPTION
Doesn’t seem like a good idea to have the static examples in this repo since they change all the time. 

cy.route() and server will be removed eventually also. 